### PR TITLE
Show parent napari when notebook is quit

### DIFF
--- a/src/napari_workshop_browser/_tests/test_widget.py
+++ b/src/napari_workshop_browser/_tests/test_widget.py
@@ -13,7 +13,7 @@ def test_workshop_widget(make_napari_viewer, capsys):
     # create our widget, passing in the viewer
     my_widget = WorkshopWidget(viewer)
 
-    viewer.window.add_dock_widget(widget)
+    viewer.window.add_dock_widget(my_widget)
 
     # We only test whether we can instantiate the widget and add to window
     assert my_widget is not None

--- a/src/napari_workshop_browser/_tests/test_widget.py
+++ b/src/napari_workshop_browser/_tests/test_widget.py
@@ -1,36 +1,19 @@
 import numpy as np
 
-from napari_workshop_browser import ExampleQWidget, example_magic_widget
+from napari_workshop_browser import WorkshopWidget
 
 
 # make_napari_viewer is a pytest fixture that returns a napari viewer object
 # capsys is a pytest fixture that captures stdout and stderr output streams
-def test_example_q_widget(make_napari_viewer, capsys):
+def test_workshop_widget(make_napari_viewer, capsys):
     # make viewer and add an image layer using our fixture
     viewer = make_napari_viewer()
     viewer.add_image(np.random.random((100, 100)))
 
     # create our widget, passing in the viewer
-    my_widget = ExampleQWidget(viewer)
+    my_widget = WorkshopWidget(viewer)
 
-    # call our widget method
-    my_widget._on_click()
+    viewer.window.add_dock_widget(widget)
 
-    # read captured output and check that it's as we expected
-    captured = capsys.readouterr()
-    assert captured.out == "napari has 1 layers\n"
-
-
-def test_example_magic_widget(make_napari_viewer, capsys):
-    viewer = make_napari_viewer()
-    layer = viewer.add_image(np.random.random((100, 100)))
-
-    # this time, our widget will be a MagicFactory or FunctionGui instance
-    my_widget = example_magic_widget()
-
-    # if we "call" this object, it'll execute our function
-    my_widget(viewer.layers[0])
-
-    # read captured output and check that it's as we expected
-    captured = capsys.readouterr()
-    assert captured.out == f"you have selected {layer}\n"
+    # We only test whether we can instantiate the widget and add to window
+    assert my_widget is not None

--- a/src/napari_workshop_browser/_widget.py
+++ b/src/napari_workshop_browser/_widget.py
@@ -130,6 +130,9 @@ class WorkshopWidget(QWidget):
 
         self.layout().addWidget(btn)
 
+    def _on_click(self):
+        self.run()
+
     def run(self):
         # Hide the original window. This is really wasteful.
         self.viewer.window._qt_window.hide()

--- a/src/napari_workshop_browser/_widget.py
+++ b/src/napari_workshop_browser/_widget.py
@@ -205,6 +205,12 @@ class WorkshopWidget(QWidget):
                 )
 
         worker = launch_jupyter_notebook()
+
+        def restore_napari():
+            self.viewer.window._qt_window.show()
+
+        worker.finished.connect(restore_napari)
+
         worker.start()
 
 

--- a/src/napari_workshop_browser/_widget.py
+++ b/src/napari_workshop_browser/_widget.py
@@ -130,10 +130,6 @@ class WorkshopWidget(QWidget):
 
         self.layout().addWidget(btn)
 
-    def _on_click(self):
-        print("napari has", len(self.viewer.layers), "layers")
-        self.run()
-
     def run(self):
         # Hide the original window. This is really wasteful.
         self.viewer.window._qt_window.hide()


### PR DESCRIPTION
We should still do more when we hide napari, like showing a floating widget that allows you to terminate the parent napari or the notebook server.